### PR TITLE
update plunkr example to not flash empty <inputs> when editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Restangular is an AngularJS service that will help you get, delete and update Restfull Resources with very few lines in the Client side. 
 This service is a perfect fit for any WebApp that uses Restfull Resources as the API for your application.
 
-**If you want to check a live example, [please click this link to plunkr](http://plnkr.co/edit/bs5Qu8D6mYXzJXR74b87?p=preview).** It's the same example as Angular's Javascript Projects but Restangularized.
+**If you want to check a live example, [please click this link to plunkr](http://plnkr.co/edit/8W9dOU).** It's the same example as Angular's Javascript Projects but Restangularized.
 
 ## Differences with $resource
 


### PR DESCRIPTION
in your original plunkr, when you click to edit a project it transitions to the 'edit' page immediately (before the request to fetch the resource from the API comes back) so it would have blank inputs for a period of time and have red 'required' next to each (until the request comes back). this changes the plunker to move it up into the 'resolve' hook in $routeProvider so it waits for the request to respond before rendering the edit action so you don't have the periodic flash of blank inputs.  I think it makes the code look more clean too.
