### PR TITLE
Fix call to isOverridenMethod in setMethodOverriders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.8.9
+* Fix call to `isOverridenMethod` in `setMethodOverriders`.
+
 #0.8.8
 * Removed extra trailling slash for elements without ID. Thanks @cboden
 

--- a/src/restangular.js
+++ b/src/restangular.js
@@ -57,7 +57,7 @@ module.provider('Restangular', function() {
             config.methodOverriders = config.methodOverriders || [];
             object.setMethodOverriders = function(values) {
               var overriders = _.extend([], values);
-              if (isOverridenMethod('delete', overriders)) {
+              if (config.isOverridenMethod('delete', overriders)) {
                 overriders.push("remove");
               }
               config.methodOverriders = overriders;


### PR DESCRIPTION
Current version throws an error when trying to `setMethodOverriders` via RestangularProvider configuration.
