### PR TITLE
Prevent url creator from duplicating slashes while building the url

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -20,7 +20,9 @@ module.provider('Restangular', function() {
              */
             config.baseUrl = _.isUndefined(config.baseUrl) ? "" : config.baseUrl;
             object.setBaseUrl = function(newBaseUrl) {
-                config.baseUrl = newBaseUrl;
+                config.baseUrl = _.last(newBaseUrl) === "/"
+                  ? _.initial(newBaseUrl).join("")
+                  : newBaseUrl;
             }
             
             /**


### PR DESCRIPTION
- The case is the following:
  BaseUrl is set to /someurl/ via RestangularProvider
  then all the built urls contain duplicated slashes like
  /someurl//Resource

Best regards,
Artyom Baranovskiy
