### PR TITLE
Adds missing semicolons and code formatting so that it is consistent

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1,6 +1,6 @@
 'use strict';
 
-(function(){
+(function() {
 
 var module = angular.module('restangular', []);
 
@@ -14,7 +14,7 @@ module.provider('Restangular', function() {
             var safeMethods= ["get", "head", "options", "trace"];
             config.isSafe = function(operation) {
               return _.contains(safeMethods, operation.toLowerCase());
-            }
+            };
             /**
              * This is the BaseURL to be used with Restangular
              */
@@ -23,15 +23,15 @@ module.provider('Restangular', function() {
                 config.baseUrl = _.last(newBaseUrl) === "/"
                   ? _.initial(newBaseUrl).join("")
                   : newBaseUrl;
-            }
+            };
             
             /**
              * Sets the extra fields to keep from the parents
              */
             config.extraFields = config.extraFields || [];
             object.setExtraFields = function(newExtraFields) {
-                config.extraFields = newExtraFields;
-            }
+              config.extraFields = newExtraFields;
+            };
 
             /**
              * Some default $http parameter to be used in EVERY call
@@ -39,21 +39,21 @@ module.provider('Restangular', function() {
             config.defaultHttpFields = config.defaultHttpFields || {};
             object.setDefaultHttpFields = function(values) {
               config.defaultHttpFields = values;
-            }
+            };
 
             config.withHttpDefaults = function(obj) {
               return _.defaults(obj, config.defaultHttpFields);
-            }
+            };
 
             config.defaultRequestParams = config.defaultRequestParams || {};
             object.setDefaultRequestParams = function(values) {
               config.defaultRequestParams = values;
-            }
+            };
 
             config.defaultHeaders = config.defaultHeaders || {};
             object.setDefaultHeaders = function(headers) {
               config.defaultHeaders = headers;
-            }
+            };
 
             /**
              * Method overriders will set which methods are sent via POST with an X-HTTP-Method-Override
@@ -65,25 +65,26 @@ module.provider('Restangular', function() {
                 overriders.push("remove");
               }
               config.methodOverriders = overriders;
-            }
+            };
 
             config.isOverridenMethod = function(method, values) {
               var search = values || config.methodOverriders;
               return !_.isUndefined(_.find(search, function(one) {
                 return one.toLowerCase() === method.toLowerCase();
               }));
-            }
+            };
 
             /**
              * Sets the URL creator type. For now, only Path is created. In the future we'll have queryParams
             **/
             config.urlCreator = config.urlCreator || "path";
             object.setUrlCreator = function(name) {
-                if (!_.has(config.urlCreatorFactory, name)) {
-                    throw new Error("URL Path selected isn't valid");
-                }
-                config.urlCreator = name;
-            }
+              if (!_.has(config.urlCreatorFactory, name)) {
+                  throw new Error("URL Path selected isn't valid");
+              }
+
+              config.urlCreator = name;
+            };
             
             /**
              * You can set the restangular fields here. The 3 required fields for Restangular are:
@@ -100,11 +101,11 @@ module.provider('Restangular', function() {
                 route: "route",
                 parentResource: "parentResource",
                 restangularCollection: "restangularCollection"
-            }
+            };
             object.setRestangularFields = function(resFields) {
                 config.restangularFields = 
                   _.extend(config.restangularFields, resFields);
-            }
+            };
 
             config.setIdToElem = function(elem, id) {
               var properties = config.restangularFields.id.split('.');
@@ -114,7 +115,7 @@ module.provider('Restangular', function() {
                 idValue = idValue[prop];
               });
               idValue[_.last(properties)] = id;
-            } 
+            };
 
             config.getIdFromElem = function(elem) {
               var properties = config.restangularFields.id.split('.');
@@ -123,7 +124,7 @@ module.provider('Restangular', function() {
                 idValue = idValue[prop];
               });
               return idValue;
-            }
+            };
             
             /**
              * Sets the Response parser. This is used in case your response isn't directly the data.
@@ -133,11 +134,12 @@ module.provider('Restangular', function() {
              * The ResponseExtractor is a function that receives the response and the method executed.
              */
             config.responseExtractor = config.responseExtractor || function(response) {
-                return response;
-            }
+              return response;
+            };
+
             object.setResponseExtractor = function(extractor) {
-                config.responseExtractor = extractor;
-            }
+              config.responseExtractor = extractor;
+            };
             
             object.setResponseInterceptor = object.setResponseExtractor;
             
@@ -151,21 +153,21 @@ module.provider('Restangular', function() {
                   headers: headers,
                   params: params
                 };
-            } 
+            };
             
             object.setRequestInterceptor = function(interceptor) {
-                config.fullRequestInterceptor = function(elem, operation, path, url, headers, params) {
-                  return {
-                    headers: headers,
-                    params: params,
-                    element: interceptor(elem, operation, path, url)
-                  }
-                };
-            }
+              config.fullRequestInterceptor = function(elem, operation, path, url, headers, params) {
+                return {
+                  headers: headers,
+                  params: params,
+                  element: interceptor(elem, operation, path, url)
+                }
+              };
+            };
 
             object.setFullRequestInterceptor = function(interceptor) {
-                config.fullRequestInterceptor = interceptor;
-            }
+              config.fullRequestInterceptor = interceptor;
+            };
 
             
 
@@ -173,7 +175,7 @@ module.provider('Restangular', function() {
 
             object.setErrorInterceptor = function(interceptor) {
               config.errorInterceptor = interceptor;
-            }
+            };
             
             /**
              * This method is called after an element has been "Restangularized".
@@ -183,11 +185,11 @@ module.provider('Restangular', function() {
              * 
              */
             config.onElemRestangularized = config.onElemRestangularized || function(elem) {
-                return elem;
-            }
+              return elem;
+            };
             object.setOnElemRestangularized = function(post) {
-                config.onElemRestangularized = post;
-            }
+              config.onElemRestangularized = post;
+            };
 
             /**
              * Depracated. Don't use this!!
@@ -198,7 +200,7 @@ module.provider('Restangular', function() {
             
             config.shouldSaveParent = config.shouldSaveParent || function() {
                 return true;
-            }
+            };
             object.setParentless = function(values) {
                 if (_.isArray(values)) {
                     config.shouldSaveParent = function(route) {
@@ -209,7 +211,7 @@ module.provider('Restangular', function() {
                         return !values;
                     }
                 }
-            }
+            };
 
             /**
              * This lets you set a suffix to every request.
@@ -223,7 +225,7 @@ module.provider('Restangular', function() {
             config.suffix = _.isUndefined(config.suffix) ? null : config.suffix;
             object.setRequestSuffix = function(newSuffix) {
                 config.suffix = newSuffix;
-            }
+            };
             
             /**
              * Add element transformers for certain routes.
@@ -250,7 +252,7 @@ module.provider('Restangular', function() {
                     }
                     return elem;
                 });
-            }
+            };
             
             object.extendCollection = function(route, fn) {
               return object.addElementTransformer(route, true, fn);
@@ -270,12 +272,12 @@ module.provider('Restangular', function() {
                 }
                 return config.onElemRestangularized(changedElem, 
                   isCollection, route, Restangular);
-            }
+            };
             
             config.fullResponse = _.isUndefined(config.fullResponse) ? false : config.fullResponse;
             object.setFullResponse = function(full) {
                 config.fullResponse = full;
-            }
+            };
             
             
             
@@ -291,7 +293,7 @@ module.provider('Restangular', function() {
 
              BaseCreator.prototype.setConfig = function(config) {
                  this.config = config;
-             }
+             };
 
              BaseCreator.prototype.parentsArray = function(current) {
                 var parents = [];
@@ -300,7 +302,7 @@ module.provider('Restangular', function() {
                     current = current[this.config.restangularFields.parentResource];
                 }
                 return parents.reverse();
-            }
+            };
 
             function RestangularResource($http, url, configurer) {
               var resource = {};
@@ -381,7 +383,7 @@ module.provider('Restangular', function() {
                       params: params,
                       headers: headers || {}})
                 });
-            }
+            };
             
             /**
              * This is the Path URL creator. It uses Path to show Hierarchy in the Rest API.
@@ -407,7 +409,7 @@ module.provider('Restangular', function() {
 
                     return currUrl;
                 }, '');
-            }
+            };
             
 
             
@@ -417,7 +419,7 @@ module.provider('Restangular', function() {
                     baseUrl += "/" + what;
                 }
                 return baseUrl;
-            }
+            };
             
 
             
@@ -762,7 +764,6 @@ module.provider('Restangular', function() {
 
           return createServiceForConfiguration(globalConfiguration);
           
-       
         }];
     }
 );


### PR DESCRIPTION
It looks like most of the code uses 2 spaces for a tab. Some code was 2 tabs for indentation. I tried to clean up some of it.
