### PR TITLE
When overriding remove set X-HTTP-Method-Override to DELETE

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -702,7 +702,7 @@ module.provider('Restangular', function() {
                   var isOverrideOperation = config.isOverridenMethod(operation);
                   if (isOverrideOperation) {
                     callOperation = 'post';
-                    callHeaders = _.extend(callHeaders, {'X-HTTP-Method-Override': operation});
+                    callHeaders = _.extend(callHeaders, {'X-HTTP-Method-Override': operation === 'remove' ? 'DELETE' : operation});
                   }
                   
                   if (config.isSafe(operation)) {


### PR DESCRIPTION
Set X-HTTP-Method-Override to DELETE when Restangular is configured with `setMethodOverriders['delete']`
