### PR TITLE
etags: add basic support for If-Match

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -423,8 +423,7 @@ module.provider('Restangular', function() {
                 var headers = _.defaults(callHeaders || {}, this.config.defaultHeaders);
                 
                 if (etag) {
-                    var _if_match_ops = ['remove', 'put', 'patch'];
-                    if (_if_match_ops.indexOf(operation) > -1) {
+                    if (!config.isSafe(operation)) {
                       headers['If-Match'] = etag;
                     } else {
                       headers['If-None-Match'] = etag;


### PR DESCRIPTION
For an API I am working with we need to set the If-Match ETags header when making DELETE requests to objects. It seems currently restangular hardcodes ETag support for If-None-Match. I have made a crude stab at modifying this behaviour.

I found this blog post [1] that explains a bit about the difference between If-Match and If-None-Match. The latter seems used for caching, while the former is necessary for resource updates to ensure consistency. I think.

[1] http://odino.org/don-t-rape-http-if-none-match-the-412-http-status-code/
