### PR TITLE
Fixed Issue #270

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -23,8 +23,8 @@ module.provider('Restangular', function() {
              */
             config.baseUrl = _.isUndefined(config.baseUrl) ? "" : config.baseUrl;
             object.setBaseUrl = function(newBaseUrl) {
-                config.baseUrl = _.last(newBaseUrl) === "/"
-                  ? _.initial(newBaseUrl).join("")
+                config.baseUrl = /\//.test(newBaseUrl)
+                  ? newBaseUrl.substring(0, newBaseUrl.length-1)
                   : newBaseUrl;
                 return this;
             };


### PR DESCRIPTION
newBaseUrl is a string. Accessing string chars as array does not
work in IE8, that's why _.initial fails.

Signed-off-by: Pankaj Singh psjinx@gmail.com
