### PR TITLE
Custom request examples misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ baseAccounts.getList().then(function (accounts) {
     
     // Custom methods are available now :).
     // GET /accounts/123/users/messages?param=myParam
-    users.customGET("messages", {param: "myParam"})
+    users.customGET({}, "messages", {param: "myParam"})
     
     var firstUser = users[0];
 
@@ -577,7 +577,7 @@ Let's see an example of this:
 Restangular.one("accounts", 123).customGET("messages")
 
 // GET /accounts/messages?param=param2
-Restangular.all("accounts").customGET("messages", {param: "param2"})
+Restangular.all("accounts").customGET({}, "messages", {param: "param2"})
 ````
 ## Copying elements
 Before modifying an object, we sometimes want to copy it and then modify the copied object. We can't use `angular.copy` for this because it'll not change the `this` binded in the functions we add to the object. In this cases, you must use `Restangular.copy(fromElement)`.


### PR DESCRIPTION
I think this part is wrong or at least misleading. If I'm mistaking, please add a bit more of documentation to explain how that works. Beginners like may have hard times with this. :wink:

Well I wanted to use the custom put and took for example the customPOST from the let's code section.

It says here that it is going to do a `POST /accounts/123/messages?param=myParam` but it is actually doing more of a `POST /accounts/123/[Object object]?param=MyParam`

I solved this by adding an empty object as first param. That seems coherent with the documentation below. the element appears before the path:
`customPOST([elem, path, params, headers])`

Now it also says that elem is optional but apparently not if there are params provided (may be that's the part to update). Anyway, I think these examples of custom http verbs are not accurate. :)

Thanks for restangular anyway, It's great! :smile:  
