### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,7 +945,6 @@ In order to get this done, you need to use the `responseExtractor`. You need to 
 RestangularProvider.setResponseExtractor(function(response) {
   var newResponse = response;
   if (angular.isArray(response)) {
-    newResponse.originalElement = [];
     angular.forEach(newResponse, function(value, key) {
       newResponse[key].originalElement = angular.copy(value);
     });


### PR DESCRIPTION
We have to set copy(value) to newResponse.originalElement[key] instead of newResponse[key].originalElement if we want to access it in originalElement.
