### PR TITLE
added missing methods to sanitize helper function

### DIFF
--- a/test/restangularSpec.js
+++ b/test/restangularSpec.js
@@ -18,7 +18,8 @@ describe("Restangular", function() {
     return _.omit(item, "route", "parentResource", "getList", "get", "post", "put", "remove", "head", "trace", "options", "patch",
       "$then", "$resolved", "restangularCollection", "customOperation", "customGET", "customPOST",
       "customPUT", "customDELETE", "customGETLIST", "$getList", "$resolved", "restangularCollection", "one", "all","doGET", "doPOST",
-      "doPUT", "doDELETE", "doGETLIST", "addRestangularMethod", "getRestangularUrl", "several");
+      "doPUT", "doDELETE", "doGETLIST", "addRestangularMethod", "getRestangularUrl", "several", "getRequestedUrl", "clone",
+      "reqParams", "withHttpConfig", "oneUrl", "allUrl", "getParentList");
   };
 
   // Load required modules


### PR DESCRIPTION
Is there a reason these were left out?
