### PR TITLE
etags: look for etag in current restangular object as fallback

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1020,7 +1020,7 @@ module.provider('Restangular', function() {
 
                   var callObj = obj || this;
                   // fallback to etag on restangular object (since for custom methods we probably don't explicitly specify the etag field)
-                  var etag = callObj[config.restangularFields.etag] || this[config.restangularFields.etag];
+                  var etag = callObj[config.restangularFields.etag] || (operation != "post" ? this[config.restangularFields.etag] : null);
 
                   if (_.isObject(callObj) && config.isRestangularized(callObj)) {
                       callObj = stripRestangular(callObj);


### PR DESCRIPTION
I found that on master branch the etags were getting dropped when using some methods, e.g. `customPUT` etc. This small patch should try to get the etag from the passed in _callObj_ first, otherwise fall back to check the current Restangular element (_this_).
