### PR TITLE
Allow a target element in Restangular.copy

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -933,8 +933,8 @@ module.provider('Restangular', function() {
                   elem[config.restangularFields.doGETLIST] = elem[config.restangularFields.customGETLIST];
               }
 
-              function copyRestangularizedElement(fromElement) {
-                  var copiedElement = angular.copy(fromElement);
+              function copyRestangularizedElement(fromElement, toElement) {
+                  var copiedElement = angular.copy(fromElement, toElement);
                   return restangularizeElem(copiedElement[config.restangularFields.parentResource],
                           copiedElement, copiedElement[config.restangularFields.route], true);
               }


### PR DESCRIPTION
When response data in a PUT request is modified by the server, it might be handy to merge the changed data into the source object. This is necessary, when the object reference is already used in other places, like in an ng-repeat loop (e.g. the child scope updates the object but the parent scope performs some sort of aggregation). 

Therefore, we would like to allow a second parameter for Restangular.copy:

```
Restangular.all('foo').getList().then(function (foos) {
    var foo = foos[0];
    foo.bar = 'blubb';
    foo.put().then(function (data) {
        Restangular.copy(data, foo);
        // (foos[0] === foo) && (foo.bar === data.bar)
    });
});
```
