### PR TITLE
config.transformLocalElements default to false

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -464,7 +464,7 @@ module.provider('Restangular', function() {
                   isCollection, route, Restangular);
             };
 
-            config.transformLocalElements = _.isUndefined(config.transformLocalElements) ? true : config.transformLocalElements;
+            config.transformLocalElements = _.isUndefined(config.transformLocalElements) ? false : config.transformLocalElements;
             object.setTransformOnlyServerElements = function(active) {
               config.transformLocalElements = !active;
             }


### PR DESCRIPTION
As per the document
#### setTransformOnlyServerElements

This sets whether transformers will be run for local objects and not by objects returned by the server. This is by default true but can be changed to false if needed (Most people won't need this).

if `setTransformOnlyServerElements` defaults to `true`, `config.transformLocalElements` should be `false`
