### PR TITLE
Fixed bug in code Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,8 @@ In order to get this done, you need to use the `responseExtractor`. You need to 
 ````javascript
 RestangularProvider.setResponseExtractor(function(response) {
   var newResponse = response;
+  newResponse.originalElement = {};
+  
   if (angular.isArray(response)) {
     angular.forEach(newResponse, function(value, key) {
       newResponse[key].originalElement = angular.copy(value);


### PR DESCRIPTION
If the response passing through the ResponseExtractor has 0 as a key, it breaks with 

```
TypeError: Cannot set property '0' of undefined
```

defining the originalElement member before populating it avoids this bug.
