### PR TITLE
Adds missing karma packages to fix Travis CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
     "grunt-bower-task": "*",
     "grunt-karma": "latest",
     "grunt-conventional-changelog": "0.0.12",
-    "grunt-zip": "*"
+    "grunt-zip": "*",
+    "karma-jasmine": "*",
+    "karma-chrome-launcher": "*",
+    "karma-firefox-launcher": "*",
+    "karma-phantomjs-launcher": "*"
   },
   "scripts": {
     "test": "grunt travis --verbose"


### PR DESCRIPTION
I needed to add a few devDependencies in order to run the tests for Restangular. Additionally, I noticed that Travis CI builds were failing due to the missing `karma-firefox-launcher`. All is well now for Travis and local builds.
