### PR TITLE
Add route to setUrlToElem for allowing custom IDs

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -245,7 +245,7 @@ module.provider('Restangular', function() {
                 return "" !== elemId && !_.isUndefined(elemId) && !_.isNull(elemId);
             };
 
-            config.setUrlToElem = function(elem, url) {
+            config.setUrlToElem = function(elem, url, route) {
               config.setFieldToElem(config.restangularFields.selfLink, elem, url);
               return this;
             };
@@ -831,7 +831,7 @@ module.provider('Restangular', function() {
                     throw new Error("Route is mandatory when creating new Restangular objects.");
                   }
                   var elem = {};
-                  config.setUrlToElem(elem, url);
+                  config.setUrlToElem(elem, url, route);
                   return restangularizeElem(parent, elem , route, false);
               }
 
@@ -841,7 +841,7 @@ module.provider('Restangular', function() {
                     throw new Error("Route is mandatory when creating new Restangular objects.");
                   }
                   var elem = {};
-                  config.setUrlToElem(elem, url);
+                  config.setUrlToElem(elem, url, route);
                   return restangularizeCollection(parent, elem , route, false);
               }
               // Promises


### PR DESCRIPTION
The ability to override `getIdFromElem` isn't useful without also override
`setIdToElem` as well. Since `setIdToElem` is called from `one()` before the
`.route` value is added, adding a `route` parameter lets a consumer override
the setter function and use the route to build the ID.  Here's an
example of how this would be used:

``` javascript
sr.configuration.setIdToElem = function (elem, value, route) {
route = route || elem.route;
elem[_.initial(route).join('') + "ID"] = value;
};
```
