### PR TITLE
Added a note to the TL;DR section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ angular.module('your-app').controller('MainCtrl', function($scope, Restangular) 
 });
 ````
 
-The Restangular service may be injected into any Controller or Directive :)
+The Restangular service may be injected into any Controller or Directive :)  
 Note: When adding Restangular as a dependency it is not capitalized 'restangular'  
       But when injected into your controller it is 'Restangular'
 


### PR DESCRIPTION
I added a note in the section "Quick Configuration for Lazy Readers" pointing out that when Restangular is added as a dependency in app.js it is not capitalized "restangular" but when it is injected into a function for use it is "Restangular". This was something that I and a Co-worker were a bit tripped up on. (We took the Lazy Reader approach).
