### PR TITLE
Add dependency on lodash to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   ],
   "dependencies": {
-    "lodash": "^2.4.1"
+    "lodash": ">=1.3.0 <2.5.0"
   },
   "devDependencies": {
     "grunt-cli": ">= 0.1.7",


### PR DESCRIPTION
Should avoid having to shim when using [browserify](https://github.com/substack/node-browserify).
