### PR TITLE
Add missing "var" keyword

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1136,7 +1136,7 @@ module.provider('Restangular', function() {
                         if (operation === "post" && !__this[config.restangularFields.restangularCollection]) {
                           resolvePromise(deferred, response, restangularizeElem(__this, elem, what, true, null, fullParams), filledObject);
                         } else {
-                          data = restangularizeElem(__this[config.restangularFields.parentResource], elem, __this[config.restangularFields.route], true, null, fullParams)
+                          var data = restangularizeElem(__this[config.restangularFields.parentResource], elem, __this[config.restangularFields.route], true, null, fullParams)
                           data[config.restangularFields.singleOne] = __this[config.restangularFields.singleOne]
                           resolvePromise(deferred, response, data, filledObject);
                         }


### PR DESCRIPTION
So it doesn't crash anymore when executed in a global strict mode.
