### PR TITLE
use stricter versions for bower-dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,8 @@
     "url": "git://github.com/mgonto/restangular.git"
   },
   "dependencies": {
-    "lodash": ">=1.3.0 <2.5.0",
-    "angular": "*"
+    "lodash": "~2.4.1",
+    "angular": "~1.2.17"
   },
   "ignore": [
     "node_modules",


### PR DESCRIPTION
So that a future incompatible version of angular does not break build for all past versions
