### PR TITLE
Add missing Restangular dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ Let's see how it works:
 
 ````js
 // Declare factory
-module.factory('Users', function() {
+module.factory('Users', function(Restangular) {
   return Restangular.service('users');
 });
 


### PR DESCRIPTION
Just a documentation fix! Missing a dependency for the de-coupling example.
