### PR TITLE
Updated README description of clone()

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ These are the methods that can be called on the Restangular object.
 * **getRestangularUrl()**: Gets the URL of the current object.
 * **getRequestedUrl()**: Gets the real URL the current object was requested with (incl. GET parameters). Will equal getRestangularUrl() when no parameters were used, before calling `get()`, or when using on a nested child.
 * **getParentList()**: Gets the parent list to which it belongs (if any)
-* **clone()**: Copies the element
+* **clone()**: Copies the element. It's an alias to calling `Restangular.copy(elem)`.
 * **plain()**: Returns the plain element received from the server without any of the enhanced methods from Restangular. It's an alias to calling `Restangular.stripRestangular(elem)`
 * **withHttpConfig(httpConfig)**: It lets you set a configuration for $http only for the next call. Check the Local Config HTTP section for an example.
 * **save**: Calling save will determine wether to do PUT or POST accordingly
@@ -724,7 +724,7 @@ These are the methods that can be called on the Restangular object.
 * **several(route, ids*)**: Used for RequestLess connections and URL Building. See section below.
 * **oneUrl(route, url)**: This will create a new Restangular object that is just a pointer to one element with the specified URL.
 * **allUrl(route, url)**: This creates a Restangular object that is just a pointer to a list at the specified URL.
-* **clone()**: Copies the collection
+* **clone()**: Copies the collection. It's an alias to calling `Restangular.copy(collection)`.
 * **withHttpConfig(httpConfig)**: It lets you set a configuration for $http only for the next call. Check the Local Config HTTP section for an example.
 
 ### Custom methods


### PR DESCRIPTION
Added a note to the docs that the `clone()` method on elements and collections is an alias to `Restangular.copy(obj)`.  Saves a bit of time over having to double check the source.  Also verified from https://github.com/mgonto/restangular/issues/299