### PR TITLE
New way to detect a Restangularized element

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -198,7 +198,8 @@ module.provider('Restangular', function() {
       withHttpConfig: 'withHttpConfig',
       singleOne: 'singleOne',
       plain: 'plain',
-      save: 'save'
+      save: 'save',
+      restangularized: 'restangularized'
     };
     object.setRestangularFields = function(resFields) {
       config.restangularFields =
@@ -207,7 +208,7 @@ module.provider('Restangular', function() {
     };
 
     config.isRestangularized = function(obj) {
-      return !!obj[config.restangularFields.one] || !!obj[config.restangularFields.all];
+      return !!obj[config.restangularFields.restangularized];
     };
 
     config.setFieldToElem = function(field, elem, value) {
@@ -758,6 +759,9 @@ module.provider('Restangular', function() {
         elem[config.restangularFields.reqParams] = _.isEmpty(reqParams) ? null : reqParams;
         elem[config.restangularFields.withHttpConfig] = _.bind(withHttpConfig, elem);
         elem[config.restangularFields.plain] = _.bind(stripRestangular, elem, elem);
+
+        // Tag element as restangularized
+        elem[config.restangularFields.restangularized] = true;
 
         // RequestLess connection
         elem[config.restangularFields.one] = _.bind(one, elem, elem);

--- a/test/restangularSpec.js
+++ b/test/restangularSpec.js
@@ -100,6 +100,14 @@ describe("Restangular", function() {
       return [500, {}, ""];
     });
 
+    $httpBackend.whenPOST("/customs").respond(function(method, url, data, headers) {
+      if (JSON.parse(data).one) {
+        return [201, "", ""];
+      } else {
+        return [400, "", ""];
+      }
+    });
+
     // return the status code given
     // e.g.: /error/404 returns 404 Not Found
     var urlRegex = /\/error\/(\d{3})/;
@@ -322,7 +330,7 @@ describe("Restangular", function() {
       $httpBackend.flush();
     });
 
-    
+
   });
 
   describe("Local data", function() {
@@ -349,7 +357,7 @@ describe("Restangular", function() {
 
       $httpBackend.flush();
 
-      expect(obj.amount).toEqual(3.1416);      
+      expect(obj.amount).toEqual(3.1416);
     });
 
     it("Shouldn't be restangularized by default", function() {
@@ -435,6 +443,15 @@ describe("Restangular", function() {
       $httpBackend.flush();
     });
 
+    it("customPOST() should add a new item", function() {
+      restangularAccounts.customPOST({id: 2, user: "Someone"}).then(function() {
+        expect(accountsModel.length).toEqual(2);
+      });
+
+      $httpBackend.expectPOST('/accounts').respond(201, '');
+      $httpBackend.flush();
+    });
+
     it("post() should work with arrays", function() {
      Restangular.all('places').post([{name: "Gonto"}, {name: 'John'}]).then(function(value) {
        expect(value.length).toEqual(2);
@@ -460,9 +477,9 @@ describe("Restangular", function() {
     it("Doing a post and then other operation (delete) should call right URLs", function() {
       restangularAccounts.post(newAccount).then(function(added) {
         added.remove();
-        $httpBackend.expectDELETE('/accounts/44').respond(201, '');   
-      });      
-      
+        $httpBackend.expectDELETE('/accounts/44').respond(201, '');
+      });
+
       $httpBackend.flush();
     });
 
@@ -597,7 +614,7 @@ describe("Restangular", function() {
       $httpBackend.expectPOST('/accounts/1');
       account1.name = "Hey";
       account1.save();
-      
+
       $httpBackend.flush();
     });
 
@@ -636,7 +653,7 @@ describe("Restangular", function() {
           newAc.remove();
           $httpBackend.expectDELETE("/accounts/1");
         });
-        $httpBackend.expectPUT("/accounts/1");        
+        $httpBackend.expectPUT("/accounts/1");
 
 
       });
@@ -702,7 +719,7 @@ describe("Restangular", function() {
       });
 
       accountsPromise = Restangular.all('accounts').getList();
-      
+
       accountsPromise.then(function(accounts) {
         expect(typeof accounts.totalAmount).toEqual("function");
       });
@@ -712,14 +729,14 @@ describe("Restangular", function() {
 
     it("should allow for a custom method to be placed at the model level when one model is requested", function() {
       var accountPromise;
-      
+
       Restangular.addElementTransformer('accounts', false, function(model) {
          model.prettifyAmount = function() {};
          return model;
       });
 
       accountPromise = Restangular.one('accounts', 1).get();
-      
+
       accountPromise.then(function(account) {
         expect(typeof account.prettifyAmount).toEqual("function");
       });
@@ -729,14 +746,14 @@ describe("Restangular", function() {
 
     it("should allow for a custom method to be placed at the model level when several models are requested", function() {
       var accountPromise;
-      
+
       Restangular.addElementTransformer('accounts', false, function(model) {
          model.prettifyAmount = function() {};
          return model;
       });
 
       accountsPromise = Restangular.all('accounts', 1).getList();
-      
+
       accountsPromise.then(function(accounts) {
         accounts.forEach(function(account, index) {
           expect(typeof account.prettifyAmount).toEqual("function");
@@ -776,47 +793,47 @@ describe("Restangular", function() {
       expect(spy).toHaveBeenCalledWith('accounts', false, fn);
     });
   });
-  
+
   describe("defaultHeaders", function() {
     it("should return defaultHeaders", function() {
       var defaultHeaders = {testheader:'header value'};
-      
+
       Restangular.setDefaultHeaders(defaultHeaders);
-      
+
       expect(Restangular.defaultHeaders).toEqual(defaultHeaders);
     });
   });
-  
+
   describe("defaultRequestParams", function() {
     it("should return defaultRequestParams", function() {
       var defaultRequestParams = {param:'value'};
-      
+
       Restangular.setDefaultRequestParams(defaultRequestParams);
-      
+
       expect(Restangular.requestParams.common).toEqual(defaultRequestParams);
     });
-    
+
     it("should be able to set default params for get, post, put.. methods separately", function() {
       var postParams = {post:'value'},
           putParams = {put:'value'};
-      
+
       Restangular.setDefaultRequestParams('post', postParams);
       expect(Restangular.requestParams.post).toEqual(postParams);
-      
+
       Restangular.setDefaultRequestParams('put', putParams);
       expect(Restangular.requestParams.put).toEqual(putParams);
-      
+
       expect(Restangular.requestParams.common).not.toEqual(putParams);
     });
-    
+
     it("should be able to set default params for multiple methods with array", function() {
       var defaultParams = {param:'value'};
-      
+
       Restangular.setDefaultRequestParams(['post', 'put'], defaultParams);
-      
+
       expect(Restangular.requestParams.post).toEqual(defaultParams);
       expect(Restangular.requestParams.put).toEqual(defaultParams);
-      
+
       expect(Restangular.requestParams.common).not.toEqual(defaultParams);
     });
   });
@@ -829,14 +846,14 @@ describe("Restangular", function() {
 
       expect(Restangular.configuration.baseUrl).toEqual('');
       expect(childRestangular.configuration.baseUrl).toEqual('/api/v1');
-      
+
     });
 
     it("should allow nested configurations", function() {
       var childRestangular = Restangular.withConfig(function(RestangularConfigurer){
         RestangularConfigurer.setBaseUrl('/api/v1');
       });
-    
+
       var grandchildRestangular = childRestangular.withConfig(function(RestangularConfigurer){
         RestangularConfigurer.setRequestSuffix('.json');
       });
@@ -900,6 +917,7 @@ describe("Restangular", function() {
       $httpBackend.flush();
     });
   });
+
   describe("setSelfLinkAbsoluteUrl", function() {
     it("works", function() {
       var childRestangular = Restangular.withConfig(function(RestangularConfigurer){
@@ -909,5 +927,16 @@ describe("Restangular", function() {
       expect(Restangular.configuration.absoluteUrl).toEqual(true);
       expect(childRestangular.configuration.absoluteUrl).toEqual(false);
     })
-  })
+  });
+
+  describe("Misc", function () {
+    it("should not strip [one] or [all] key from plain object", function () {
+      Restangular.all("customs").customPOST({one: 'I am here', two: 'I am also here'}).then(function () {
+        expect(1).toBe(1);
+      }, function () {
+        expect("Promise").toBe("correctly fulfilled");
+      });
+      $httpBackend.flush();
+    });
+  });
 });


### PR DESCRIPTION
Actually: if a plain object has a key `one` or `all`, it will be detected as Restangularized and those keys will be removed, which is wrong.

Added a new specific key `restangularized` that I set to `true` when the element is restangularized and use it for detection. I hope I didn't forget any place where to set this flag.
