### PR TITLE
Fixed odd parsing of array of strings

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -900,7 +900,7 @@ module.provider('Restangular', function() {
         if (_.isArray(elem)) {
           var array = [];
           _.each(elem, function(value) {
-              array.push(stripRestangular(value));
+              array.push(_.isObject(value) ?  stripRestangular(value) : value);
           });
           return array;
         } else {


### PR DESCRIPTION
I made stripAngular check if the elem value is an object or not. This
way, it will push it in as a string if not or run it through
stripRestangular again. This is to address bug #815.
