### PR TITLE
Update README: remove reference to listTypeIsArray (deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,7 +1061,7 @@ So, let's assume that your data is the following:
 }
 ````
 
-In this case, you'd need to configure Restangular's `responseExtractor`. See the following:
+In this case, you'd need to use RestangularProvider's `addResponseInterceptor`. See the following:
 
 ````javascript
 app.config(function(RestangularProvider) {


### PR DESCRIPTION
The answer in README.md to "My response is actually wrapped with some metadata. How do I get the data in that case?" was confusing because it contained an orphaned reference to the deprecated listTypeIsArray.  This commit just removes the reference, so the answer is up to date and consistent.
