### PR TITLE
Clarify Error Message

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -804,7 +804,7 @@ module.provider('Restangular', function() {
       function one(parent, route, id, singleOne) {
         if (_.isNumber(route) || _.isNumber(parent)) {
           var error = 'You\'re creating a Restangular entity with the number ';
-          error += 'instead of the route or the parent. You can\'t call .one(12)';
+          error += 'instead of the route or the parent. For example, you can\'t call .one(12)';
           throw new Error(error);
         }
         var elem = {};


### PR DESCRIPTION
Change "You can't call .one(12)" -> "For example, you can't call .one(12)." This clarifies the expression to make sure people understand .one(12) call is an example of something you can't do.
