### PR TITLE
Missing argument for hooking up the relationship between elements and its wrapper collection

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -989,7 +989,7 @@ module.provider('Restangular', function() {
       function restangularizeCollectionAndElements(parent, element, route) {
         var collection = restangularizeCollection(parent, element, route, false);
         _.each(collection, function(elem) {
-          restangularizeElem(parent, elem, route, false);
+          restangularizeElem(parent, elem, route, false, collection);
         });
         return collection;
       }

--- a/test/restangularSpec.js
+++ b/test/restangularSpec.js
@@ -345,6 +345,7 @@ describe("Restangular", function() {
       expect(collection.getRestangularUrl()).toBe('/accounts');
       expect(collection[0].getRestangularUrl()).toBe('/accounts/0');
 
+      expect(collection[0].getParentList()).toBe(collection);
     });
   });
 


### PR DESCRIPTION
Manually creating a collection using `restangularizeCollection()` was not passing the newly created collection to all its children elements, therefore not having the relation between the elements to its parent collection.

All the code was already there, just missing the argument to pass to `restangularizeElem()`
