### PR TITLE
Fix #697: copyRestangularizedElement should keep original fromServer attribute.

### DIFF
--- a/dist/restangular.js
+++ b/dist/restangular.js
@@ -946,7 +946,8 @@ module.provider('Restangular', function() {
               function copyRestangularizedElement(fromElement, toElement) {
                   var copiedElement = angular.copy(fromElement, toElement);
                   return restangularizeElem(copiedElement[config.restangularFields.parentResource],
-                          copiedElement, copiedElement[config.restangularFields.route], true);
+                          copiedElement, copiedElement[config.restangularFields.route],
+                          copiedElement[config.restangularFields.fromServer]);
               }
 
               function restangularizeElem(parent, element, route, fromServer, collection, reqParams) {

--- a/src/restangular.js
+++ b/src/restangular.js
@@ -933,7 +933,8 @@ module.provider('Restangular', function() {
       function copyRestangularizedElement(fromElement, toElement) {
         var copiedElement = angular.copy(fromElement, toElement);
         return restangularizeElem(copiedElement[config.restangularFields.parentResource],
-                copiedElement, copiedElement[config.restangularFields.route], true);
+                copiedElement, copiedElement[config.restangularFields.route],
+                copiedElement[config.restangularFields.fromServer]);
       }
 
       function restangularizeElem(parent, element, route, fromServer, collection, reqParams) {


### PR DESCRIPTION
This is a simple fix for #697 .
