### PR TITLE
PayPal SVG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #Restangular
 
 [![Build Status](https://travis-ci.org/mgonto/restangular.svg?branch=master)](https://travis-ci.org/mgonto/restangular)
-[![PayPayl donate button](http://img.shields.io/paypal/donate.png?color=yellow)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=martin%40gon%2eto&lc=US&item_name=Martin%20Gontovnikas&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted "Donate once-off to this project using Paypal")
+[![PayPayl donate button](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=martin%40gon%2eto&lc=US&item_name=Martin%20Gontovnikas&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted "Donate once-off to this project using Paypal")
 [![Donate on Gittip](http://img.shields.io/gittip/mgonto.svg)](https://www.gittip.com/mgonto/)
 <a href="https://twitter.com/intent/tweet?hashtags=&original_referer=http%3A%2F%2Fgithub.com%2F&text=Check+out+Restangular%2C+a+service+for+%23AngularJS+that+makes+it+easy+to+use+Rest+APIs&tw_p=tweetbutton&url=https%3A%2F%2Fgithub.com%2Fmgonto%2Frestangular" target="_blank">
   <img src="http://jpillora.com/github-twitter-button/img/tweet.png"></img>
@@ -1161,14 +1161,14 @@ With that, you'd get what you need :)
 
 #### **How can I send files in my request using Restangular?**
 
-This can be done using the customPOST / customPUT method. Look at the following example: 
+This can be done using the customPOST / customPUT method. Look at the following example:
 ````js
 Restangular.all('users')
           .withHttpConfig({transformRequest: angular.identity})
-          .customPOST(formData, undefined, undefined, 
+          .customPOST(formData, undefined, undefined,
             { 'Content-Type': undefined });
 ````
-This basically tells the request to use the *Content-Type: multipart/form-data* as the header. Also *formData* is the body of the request, be sure to add all the params here, including the File you want to send of course. There is an issue already closed but with a lot of information from other users and @mgonto as well: [GitHub - Restangular](https://github.com/mgonto/restangular/issues/420) 
+This basically tells the request to use the *Content-Type: multipart/form-data* as the header. Also *formData* is the body of the request, be sure to add all the params here, including the File you want to send of course. There is an issue already closed but with a lot of information from other users and @mgonto as well: [GitHub - Restangular](https://github.com/mgonto/restangular/issues/420)
 
 #### **How do I handle CRUD operations in a List returned by Restangular?**
 


### PR DESCRIPTION
The TravisCI badge was a little misleading. You would go to the repo, knowing that master had been passing but would see (kinda) false failures. This being that the TravisCI badge was showing _all_ branch results, not just master. I've changed the TravisCI badge to be SVG and show master only so newcomers can feel comfortable in choosing a passing library.

Also updated the paypal badge to be svg.