### PR TITLE
Amended toService enabling the provision of a one-off httpConfig

### DIFF
--- a/dist/restangular.js
+++ b/dist/restangular.js
@@ -1290,6 +1290,7 @@ restangular.provider('Restangular', function() {
         serv.one = _.bind(one, (parent || service), parent, route);
         serv.post = _.bind(collection.post, collection);
         serv.getList = _.bind(collection.getList, collection);
+        serv.withHttpConfig = _.bind(collection.withHttpConfig, collection);
 
         for (var prop in collection) {
           if (collection.hasOwnProperty(prop) && _.isFunction(collection[prop]) && !_.contains(knownCollectionMethods, prop)) {

--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1285,6 +1285,7 @@ restangular.provider('Restangular', function() {
         serv.one = _.bind(one, (parent || service), parent, route);
         serv.post = _.bind(collection.post, collection);
         serv.getList = _.bind(collection.getList, collection);
+        serv.withHttpConfig = _.bind(collection.withHttpConfig, collection);
 
         for (var prop in collection) {
           if (collection.hasOwnProperty(prop) && _.isFunction(collection[prop]) && !_.contains(knownCollectionMethods, prop)) {


### PR DESCRIPTION
This was a bug IMHO. All other restangular resources allow for providing a one-off httpConfig to be used with a subsequent server request. There is no way, to provide a httpConfig for POST-requests issued by objects created with toService. I don't see a reason why this shouldn't be allowed for .service created ones as well...

This problem was also brought up in Issue #420 

Tests pass. I'm happy to add a unit test, but I'm not sure if that's the "final spec" for objects created by toService.