### PR TITLE
Updated README file. Commented url modified for 'Chain methods together to easily build complex requests' example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ These are the methods that can be called on the Restangular object.
 * **all(route)**: This will create a new Restangular object that is just a pointer to a list of elements for the specified path.
 * **oneUrl(route, url)**: This will create a new Restangular object that is just a pointer to one element with the specified URL.
 * **allUrl(route, url)**: This creates a Restangular object that is just a pointer to a list at the specified URL.
-* **copy(fromElement)**: This will create a copy of the from element so that we can modified the copied one.
+* **copy(fromElement)**: This will create a copy of the from element so that we can modify the copied one.
 * **restangularizeElement(parent, element, route, queryParams)**: Restangularizes a new element
 * **restangularizeCollection(parent, element, route, queryParams)**: Restangularizes a new collection
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $scope.user.sendMessage();  // POST: /users/123/sendMessage
 
 // Chain methods together to easily build complex requests
 $scope.user.one('messages', 123).one('from', 123).getList('unread');
-// GET: /user/123/messages/123/from/123/unread
+// GET: /users/123/messages/123/from/123/unread
 
 
 ````


### PR DESCRIPTION
In **Differences with $resource** section, under examples the given commented url is as follows
`// GET: /user/123/messages/123/from/123/unread`
but the url should be 
`// GET: /users/123/messages/123/from/123/unread`.
Only change is `users` should be there instead of just `user`.