### PR TITLE
Browserify angular dependency injection compatiblity

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1329,8 +1329,12 @@ restangular.provider('Restangular', function() {
 
 })();
 
+
+/**
+ * This lets you inject the module into angularjs using the commonjs require
+ * syntax with browserify.
+ */
 /* jshint ignore:start */
-/* commonjs package manager support (eg componentjs, browserify) */
 if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports){
  var _ = require('lodash');
  module.exports = 'restangular';

--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1328,3 +1328,11 @@ restangular.provider('Restangular', function() {
 });
 
 })();
+
+/* jshint ignore:start */
+/* commonjs package manager support (eg componentjs, browserify) */
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports){
+ var _ = require('lodash');
+ module.exports = 'restangular';
+}
+/* jshint ignore:end */


### PR DESCRIPTION
This will allow users of browserify to inject Restangular into AngularJS using the CommonJS require syntax. 

For example:

````
var angular = require('angular');
angular.module('myApp', [
  require('angular-animate'),
  require('angular-route'),
  require('restangular'),
]);
````

Resolves https://github.com/mgonto/restangular/issues/749