### PR TITLE
accept a fromServer param for restangularizeCollection

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -986,10 +986,10 @@ restangular.provider('Restangular', function() {
         return config.transformElem(localElem, true, route, service, true);
       }
 
-      function restangularizeCollectionAndElements(parent, element, route) {
-        var collection = restangularizeCollection(parent, element, route, false);
+      function restangularizeCollectionAndElements(parent, element, route, fromServer) {
+        var collection = restangularizeCollection(parent, element, route, fromServer);
         _.each(collection, function(elem) {
-          restangularizeElem(parent, elem, route, false);
+          restangularizeElem(parent, elem, route, fromServer);
         });
         return collection;
       }


### PR DESCRIPTION
restangularizeColleciton is actually mapped to restangularizeCollectionAndElements which does not accept a parameter for "fromServer".  This causes elements in the collection to perform "POST" requests when element.save() is called.  I would like to set fromServer to true so that a proper "PUT" request will be executed.

A current hack to get around this is do to something like this:
Restangular.restangularizeCollection(test, test.samples, 'samples');
 _.each test.samples, (sample) -> sample.fromServer = true

I would like to merge this unless there is good reason for why "false" is explicitly being passed.

Thanks