### PR TITLE
Fixes #1115

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -637,7 +637,11 @@ restangular.provider('Restangular', function() {
 
     Path.prototype.normalizeUrl = function (url){
       var parts = /(http[s]?:\/\/)?(.*)?/.exec(url);
-      parts[2] = parts[2].replace(/[\\\/]+/g, '/');
+
+      if (parts[2].indexOf('//') !== 0) {
+        parts[2] = parts[2].replace(/[\\\/]+/g, '/');
+      }
+
       return (typeof parts[1] !== 'undefined')? parts[1] + parts[2] : parts[2];
     };
 

--- a/test/restangularSpec.js
+++ b/test/restangularSpec.js
@@ -163,6 +163,7 @@ describe("Restangular", function() {
     $httpBackend.whenGET("/customers/").respond(customers);
     $httpBackend.whenGET("http://localhost:8080/customers/").respond(customers);
     $httpBackend.whenGET("api.new.domain/customers/").respond(customers);
+    $httpBackend.whenGET("//api.new.domain/customers").respond(customers);
     $httpBackend.whenGET("/customers/?active=true").respond(customers);
     $httpBackend.whenGET("/customers/publications/?tags=chemistry").respond(publications);
     $httpBackend.whenPUT("/customers/0").respond(function (method, url, data) {
@@ -1132,5 +1133,18 @@ describe("Restangular", function() {
 
       $httpBackend.flush();
     });
+
+    it("should not manipulate base URL when it starts with `//`", function() {
+
+      var newApi = Restangular.withConfig(function(RestangularConfigurer){
+        RestangularConfigurer.setBaseUrl('//api.new.domain');
+      });
+
+      expect(newApi.configuration.baseUrl).toEqual('//api.new.domain');
+      newApi.all("customers").getList();
+      $httpBackend.expectGET('//api.new.domain/customers');
+
+      $httpBackend.flush();
+    })
   });
 });


### PR DESCRIPTION
As it was pointed out on Issue #1115, base urls that start with `//` got manipulated in a way that broke things.

Prior to this change the following happened:
Base url: `//api.domain`
Restangular.all('accounts').getList()
Requests would look like: `http://current-server.com/api.domain/accounts`

Now It looks as it should:
Base url: `//api.domain`
Restangular.all('accounts').getList()
Requests would look like: `//api.domain/accounts`