### PR TITLE
Fix missing 'get' in decoupled service

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1305,6 +1305,7 @@ restangular.provider('Restangular', function() {
         serv.one = _.bind(one, (parent || service), parent, route);
         serv.post = _.bind(collection.post, collection);
         serv.getList = _.bind(collection.getList, collection);
+        serv.get = _.bind(collection.get, collection);
 
         for (var prop in collection) {
           if (collection.hasOwnProperty(prop) && _.isFunction(collection[prop]) && !_.contains(knownCollectionMethods, prop)) {


### PR DESCRIPTION
Adds missing 'get' function to decoupled restangular services.

Presently this example fails with `TypeError: Users.get is not a function`:

```
// Declare factory
module.factory('Users', function(Restangular) {
  return Restangular.service('users');
});

// In your controller you inject Users
Users.get(2) // GET to /users/2
Users.post({data}) // POST to /users
```
