### PR TITLE
Avoid restangularizing an undefined element in restangularizeCollectionAndElements

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1001,7 +1001,9 @@ restangular.provider('Restangular', function() {
       function restangularizeCollectionAndElements(parent, element, route) {
         var collection = restangularizeCollection(parent, element, route, false);
         _.each(collection, function(elem) {
-          restangularizeElem(parent, elem, route, false);
+          if (elem) {
+            restangularizeElem(parent, elem, route, false);
+          }
         });
         return collection;
       }

--- a/test/restangularSpec.js
+++ b/test/restangularSpec.js
@@ -431,6 +431,16 @@ describe("Restangular", function() {
       expect(collection[0].getRestangularUrl()).toBe('/accounts/0');
 
     });
+
+    it("Should restangularize a function with arguments OK", function() {
+      var collection = function(a, b) { };
+
+      Restangular.restangularizeCollection(null, collection, 'accounts');
+
+      expect(_.has(collection, 'get')).toBe(true);
+
+      expect(collection.getRestangularUrl()).toBe('/accounts');
+    });
   });
 
   describe("restangularizePromiseIntercept", function() {


### PR DESCRIPTION
This is a simple change that ensures an element in `restangularizeCollectionAndElements` is not falsy before trying to restangularize it. Since `restangularizeElem` expects the element to be an object of some sort, my `undefined` elements were causing a script error.

I use restangularized constructor functions for my data model (there is probably a better way to do this now, but it still works great) and encountered a script error when I added arguments to a constructor. I had always just apply'd all args through to the super constructor but in this case I wanted to do some pre-processing. Well, functions provide a .length corresponding to the number of arguments and are therefore iterable. When you try to iterate a function object there are no values so it was trying to restangularize `undefined` for each of my constructor arguments.

The test that was failing before this pull request:
```      
var collection = function(a, b) { };
Restangular.restangularizeCollection(null, collection, 'accounts');
```
> TypeError: Cannot set property 'route' of undefined
>     at restangularizeBase (/Users/ian/src/restangular/src/restangular.js:765:46)
>     at restangularizeElem (/Users/ian/src/restangular/src/restangular.js:954:25)
>     at /Users/ian/src/restangular/src/restangular.js:1004:11
>     at baseEach (http://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.3.0/lodash.js:1853:13)
>     at Function.forEach (http://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.3.0/lodash.js:5956:11)
>     at Object.restangularizeCollectionAndElements (/Users/ian/src/restangular/src/restangular.js:1003:11)
>     at Object.wrapper [as restangularizeCollection] (http://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.3.0/lodash.js:2997:56)
>     at null.<anonymous> (/Users/ian/src/restangular/test/restangularSpec.js:438:19)
