### PR TITLE
it should include common methods.

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1307,7 +1307,7 @@ restangular.provider('Restangular', function() {
         serv.getList = _.bind(collection.getList, collection);
 
         for (var prop in collection) {
-          if (collection.hasOwnProperty(prop) && _.isFunction(collection[prop]) && !_.contains(knownCollectionMethods, prop)) {
+          if (collection.hasOwnProperty(prop) && _.isFunction(collection[prop]) && _.contains(knownCollectionMethods, prop)) {
             serv[prop] = _.bind(collection[prop], collection);
           }
         }


### PR DESCRIPTION
The common methods should be to include instead of to exclude.
It must be careless to add the Not operator. This PR is to remove the Not operator.
