### PR TITLE
Depend on lodash 3.x until tested on a newer version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/mgonto/restangular.git"
   },
   "dependencies": {
-    "lodash": ">=1.3.0",
+    "lodash": "~3.x",
     "angular": "~1.x"
   },
   "ignore": [


### PR DESCRIPTION
Fixes #1294 

When using lodash 4.x, Restangular fails to `GET lib/lodash/lodash.min.js`, which returns a 404.

Specifying major version dependency for lodash 3.x until 4.x compatibility is fully tested.

4.x does ship with lodash.min.js in the dist/ directory, but it's unclear if everything else works as intended, so tying to 3.x for now seems like a good idea.