### PR TITLE
Fixing issue#1294.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/mgonto/restangular.git"
   },
   "dependencies": {
-    "lodash": ">=1.3.0",
+    "lodash": "3.10.1",
     "angular": "~1.x"
   },
   "ignore": [


### PR DESCRIPTION
 Lodash release v4.0.0 which has removed many function aliases and current bower dependency causes it to be downloaded and causes issues with other libraries using restangular.