### PR TITLE
Correct GET operation for services in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ module.factory('Users', function(Restangular) {
 });
 
 // In your controller you inject Users
-Users.get(2) // GET to /users/2
+Users.one(2).get() // GET to /users/2
 Users.post({data}) // POST to /users
 
 // GET to /users


### PR DESCRIPTION
According to https://github.com/mgonto/restangular/blob/3ff1bcc5dc723e3e19b06e800e8949f69a4357ea/src/restangular.js#L1247 only 3 operations (`one`, `post` and `getList`) are allowed. Using `get(:id)` does not work.