### PR TITLE
Honor authority without schema in url

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1,9 +1,9 @@
 (function (root, factory) {
   // https://github.com/umdjs/umd/blob/master/templates/returnExports.js
   if (typeof define === 'function' && define.amd) {
-    define(['angular', 'lodash'], factory);
+    define(['lodash', 'angular'], factory);
   } else if (typeof module === 'object' && module.exports) {
-    module.exports = factory(require('angular'), require('lodash'));
+    module.exports = factory(require('lodash'), require('angular'));
   } else {
     // No global export, Restangular will register itself as Angular.js module
     factory(root._, root.angular);

--- a/src/restangular.js
+++ b/src/restangular.js
@@ -648,7 +648,7 @@ restangular.provider('Restangular', function() {
     Path.prototype = new BaseCreator();
 
     Path.prototype.normalizeUrl = function (url){
-      var parts = /(http[s]?:\/\/)?(.*)?/.exec(url);
+      var parts = /((?:http[s]?:)?\/\/)?(.*)?/.exec(url);
       parts[2] = parts[2].replace(/[\\\/]+/g, '/');
       return (typeof parts[1] !== 'undefined')? parts[1] + parts[2] : parts[2];
     };

--- a/test/restangularSpec.js
+++ b/test/restangularSpec.js
@@ -1149,5 +1149,16 @@ describe("Restangular", function() {
 
       $httpBackend.flush();
     });
+
+    it("Should work with absolute URL with //authority", function() {
+      var newRes = Restangular.withConfig(function(RestangularConfigurer){
+        RestangularConfigurer.setBaseUrl('//localhost:8080');
+      });
+      expect(newRes.configuration.baseUrl).toEqual('//localhost:8080');
+      newRes.all("customers////").getList();
+      $httpBackend.expectGET('//localhost:8080/customers/').respond([]);
+
+      $httpBackend.flush();
+    });
   });
 });


### PR DESCRIPTION
Also fixed wrong positional arguments swapped 'angular' and 'lodash'.
Updated dependency requires lodash >=1.3.1