### PR TITLE
chore(build pipeline and tests)

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,6 @@
 // Karma configuration
 
-var angularVersion = '1.6.0';
+var angularVersion = '1.5.9';
 var lodashVersion = '4.17.2';
 
 module.exports = function (config) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,19 +1,21 @@
 // Karma configuration
-// Generated on Fri Aug 09 2013 14:14:35 GMT-0500 (CDT)
 
-module.exports = function(config) {
+var angularVersion = '1.6.0';
+var lodashVersion = '4.17.2';
+
+module.exports = function (config) {
   config.set({
 
     // base path, that will be used to resolve files and exclude
     basePath: '',
 
-    frameworks: ["jasmine"],
+    frameworks: ['jasmine'],
 
     // list of files / patterns to load in the browser
     files: [
-      'https://ajax.googleapis.com/ajax/libs/angularjs/1.3.12/angular.js',
-      'https://ajax.googleapis.com/ajax/libs/angularjs/1.3.12/angular-mocks.js',
-      'http://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.3.0/lodash.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/angular.js/' + angularVersion + '/angular.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/angular.js/' + angularVersion + '/angular-mocks.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/' + lodashVersion + '/lodash.js',
       'src/restangular.js',
       'test/*.js'
     ],

--- a/karma.underscore.conf.js
+++ b/karma.underscore.conf.js
@@ -1,19 +1,22 @@
-// Karma configuration
-// Generated on Fri Aug 09 2013 14:14:35 GMT-0500 (CDT)
+// Karma configuration for use with underscore instead of lodash
 
-module.exports = function(config) {
+var angularVersion = '1.6.0';
+var underscoreVersion = '1.8.3';
+
+
+module.exports = function (config) {
   config.set({
 
     // base path, that will be used to resolve files and exclude
     basePath: '',
 
-    frameworks: ["jasmine"],
+    frameworks: ['jasmine'],
 
     // list of files / patterns to load in the browser
     files: [
-      'https://ajax.googleapis.com/ajax/libs/angularjs/1.3.0-beta.6/angular.js',
-      'https://ajax.googleapis.com/ajax/libs/angularjs/1.3.0-beta.6/angular-mocks.js',
-      'http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.1/underscore.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/angular.js/' + angularVersion + '/angular.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/angular.js/' + angularVersion + '/angular-mocks.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/underscore.js/' + underscoreVersion + '/underscore.js',
       'src/restangular.js',
       'test/*.js'
     ],

--- a/karma.underscore.conf.js
+++ b/karma.underscore.conf.js
@@ -1,6 +1,6 @@
 // Karma configuration for use with underscore instead of lodash
 
-var angularVersion = '1.6.0';
+var angularVersion = '1.5.9';
 var underscoreVersion = '1.8.3';
 
 

--- a/package.json
+++ b/package.json
@@ -51,10 +51,7 @@
     "karma-firefox-launcher": "~0.1.3",
     "karma-jasmine": "~0.1.5",
     "karma-mocha-reporter": "0.2.8",
-    "karma-jasmine": "~0.1.5",
-    "karma-chrome-launcher": "~0.1.2",
-    "karma-phantomjs-launcher": "~0.1.2",
-    "karma-firefox-launcher": "~0.1.3"
+    "karma-phantomjs-launcher": "~0.1.2"
   },
   "scripts": {
     "test": "grunt test --verbose"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Restful Resources service for AngularJS apps",
   "version": "1.5.2",
   "filename": "restangular.min.js",
-  "main": "./dist/restangular.min.js",
+  "main": "./dist/restangular.js",
   "homepage": "https://github.com/mgonto/restangular",
   "author": "Martin Gontovnikas <martin@gon.to>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "grunt-conventional-changelog": "0.0.12",
     "grunt-zip": "*",
     "karma": "^0.13.19",
-    "karma-chrome-launcher": "~0.1.2",
-    "karma-firefox-launcher": "~0.1.3",
+    "karma-chrome-launcher": "~v2.0.0",
+    "karma-firefox-launcher": "~v1.0.0",
     "karma-jasmine": "~0.1.5",
     "karma-mocha-reporter": "0.2.8",
-    "karma-phantomjs-launcher": "~0.1.2"
+    "karma-phantomjs-launcher": "~v1.0.2"
   },
   "scripts": {
     "test": "grunt test --verbose"


### PR DESCRIPTION
* deleted duplicate dependencies keys
* updated build dependencies
* changed main file to unminified version - best practice for module bundlers
* pin angular to 1.5.9 in tests untill test in 1.6 do not fail