### PR TITLE
Fixes #1257 - Accept (number) 0 as response in get()

### DIFF
--- a/src/restangular.js
+++ b/src/restangular.js
@@ -1184,7 +1184,8 @@ restangular.provider('Restangular', function() {
           var fullParams = response.config.params;
           var elem = parseResponse(resData, operation, route, fetchUrl, response, deferred);
 
-          if (elem) {
+          // accept 0 as response
+          if (elem !== null && elem !== undefined && elem !== '') {
             var data;
 
             if (true === config.plainByDefault) {

--- a/test/restangularSpec.js
+++ b/test/restangularSpec.js
@@ -102,6 +102,10 @@ describe('Restangular', function() {
       return [500, {}, ''];
     });
 
+    $httpBackend.whenGET('/misc/zero').respond(function() {
+      return [200, 0, ''];
+    });
+
     $httpBackend.whenPOST('/customs').respond(function(method, url, data, headers) {
       if (JSON.parse(data).one) {
         return [201, '', ''];
@@ -1133,6 +1137,13 @@ describe('Restangular', function() {
 
     it('should not stip non-restangularized elements', function () {
       expect(Restangular.stripRestangular(['test','test2'])).toEqual(['test','test2']);
+    });
+
+    it('should accept 0 as response', function () {
+      Restangular.one('misc', 'zero').get().then(function(res) {
+        expect(res).toEqual(0);
+      });
+      $httpBackend.flush();
     });
   });
 


### PR DESCRIPTION
Per testcase [Doing a post to a server that returns no element will return undefined](https://github.com/mgonto/restangular/blob/master/test/restangularSpec.js#L625) `''` shall not be accepted which makes sense, but 0 is a real use case, f.e. when receiving a count.